### PR TITLE
Support base install path customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 #### properties
 
 - `version`: The version to install. Default: 8.0.36
-- `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
+- `base_install_path`: Base path of the install directory. Default: /opt
+- `install_path`: Full path to the install directory. Default: /BASEINSTALLPATH/tomcat_INSTANCENAME_VERSION
 - `tarball_base_path`: The base path to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `checksum_base_path`: The base path to the apache mirror containing the md5 file. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `tarball_uri`: The complete path to the tarball. If specified would override (`tarball_base_path` and `checksum_base_path`). checksum will be loaded from "#{tarball_uri}.md5". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus.

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,6 +1,7 @@
 property :instance_name, String, name_property: true
 property :version, String, default: '8.0.36'
-property :install_path, String, default: lazy { |r| "/opt/tomcat_#{r.instance_name}_#{r.version.tr('.', '_')}/" }
+property :base_install_path, String, default: '/opt'
+property :install_path, String, default: lazy { |r| ::File.join(r.base_install_path, "tomcat_#{r.instance_name}_#{r.version.tr('.', '_')}/") }
 property :tarball_base_path, String, default: 'http://archive.apache.org/dist/tomcat/'
 property :checksum_base_path, String, default: 'http://archive.apache.org/dist/tomcat/'
 property :sha1_base_path, String # this is the legacy name for this attribute
@@ -139,7 +140,7 @@ action :install do
   end
 
   # create a link that points to the latest version of the instance
-  link "/opt/tomcat_#{new_resource.instance_name}" do
+  link ::File.join(new_resource.base_install_path, "tomcat_#{new_resource.instance_name}") do
     to new_resource.install_path
   end
 end

--- a/test/cookbooks/test/recipes/custom_base_path_example.rb
+++ b/test/cookbooks/test/recipes/custom_base_path_example.rb
@@ -1,0 +1,6 @@
+include_recipe 'java'
+
+tomcat_install 'custom_path' do
+  tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.36/bin/apache-tomcat-8.0.36.tar.gz'
+  base_install_path '/opt/custom'
+end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,3 +2,4 @@ apt_update 'update' if platform_family?('debian')
 
 include_recipe 'test::docs_example'
 include_recipe 'test::helloworld_example'
+include_recipe 'test::custom_base_path_example'

--- a/test/cookbooks/test/recipes/helloworld_example.rb
+++ b/test/cookbooks/test/recipes/helloworld_example.rb
@@ -14,6 +14,7 @@ tomcat_install 'helloworld' do
   tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.36/bin/apache-tomcat-8.0.36.tar.gz'
   tomcat_user 'cool_user'
   tomcat_group 'cool_group'
+  base_install_path '/opt/custom'
 end
 
 # Drop off our own server.xml that uses a non-default port setup

--- a/test/cookbooks/test/recipes/helloworld_example.rb
+++ b/test/cookbooks/test/recipes/helloworld_example.rb
@@ -14,7 +14,6 @@ tomcat_install 'helloworld' do
   tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.36/bin/apache-tomcat-8.0.36.tar.gz'
   tomcat_user 'cool_user'
   tomcat_group 'cool_group'
-  base_install_path '/opt/custom'
 end
 
 # Drop off our own server.xml that uses a non-default port setup

--- a/test/integration/multi-instance/default_spec.rb
+++ b/test/integration/multi-instance/default_spec.rb
@@ -1,7 +1,11 @@
-describe file('/opt/tomcat_helloworld_8_0_36/LICENSE') do
+describe file('/opt/custom/tomcat_helloworld_8_0_36/LICENSE') do
   it { should be_file }
   it { should be_owned_by 'cool_user' }
   its('group') { should eq 'cool_group' }
+end
+
+describe file('/opt/custom/tomcat_helloworld') do
+  it { should be_symlink }
 end
 
 describe file('/opt/special/tomcat_docs_7_0_42/LICENSE') do

--- a/test/integration/multi-instance/default_spec.rb
+++ b/test/integration/multi-instance/default_spec.rb
@@ -1,17 +1,23 @@
-describe file('/opt/custom/tomcat_helloworld_8_0_36/LICENSE') do
+describe file('/opt/tomcat_helloworld_8_0_36/LICENSE') do
   it { should be_file }
   it { should be_owned_by 'cool_user' }
   its('group') { should eq 'cool_group' }
-end
-
-describe file('/opt/custom/tomcat_helloworld') do
-  it { should be_symlink }
 end
 
 describe file('/opt/special/tomcat_docs_7_0_42/LICENSE') do
   it { should be_file }
   it { should be_owned_by 'tomcat_docs' }
   its('group') { should eq 'tomcat_docs' }
+end
+
+describe file('/opt/custom/tomcat_custom_path_8_0_36/LICENSE') do
+  it { should be_file }
+  it { should be_owned_by 'cool_user' }
+  its('group') { should eq 'cool_group' }
+end
+
+describe file('/opt/custom/tomcat_custom_path') do
+  it { should be_symlink }
 end
 
 describe command('curl http://localhost:8081/sample/') do


### PR DESCRIPTION
### Description

The base install path was hardcoded to /opt. There are two issues with this hardcoded value:
- The symlink can't be customized
- User lost the automated generation (tomcat_INSTANCENAME_VERSION) of install_path when they just want to change /opt to somewhere else
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
