### PR TITLE
add missing setenv.sh

### DIFF
--- a/resources/service_systemd.rb
+++ b/resources/service_systemd.rb
@@ -79,6 +79,17 @@ action_class.class_eval do
   def create_init
     ensure_catalina_base
 
+    template "#{derived_install_path}/bin/setenv.sh" do
+      source 'setenv.erb'
+      mode '0755'
+      cookbook 'tomcat'
+      sensitive new_resource.sensitive
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
+      variables(
+        env_vars: new_resource.env_vars
+      )
+    end
+
     template "/etc/systemd/system/tomcat_#{instance_name}.service" do
       source 'init_systemd.erb'
       sensitive new_resource.sensitive

--- a/resources/service_upstart.rb
+++ b/resources/service_upstart.rb
@@ -65,6 +65,17 @@ action_class.class_eval do
   def create_init
     ensure_catalina_base
 
+    template "#{derived_install_path}/bin/setenv.sh" do
+      source 'setenv.erb'
+      mode '0755'
+      cookbook 'tomcat'
+      sensitive new_resource.sensitive
+      notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
+      variables(
+        env_vars: new_resource.env_vars
+      )
+    end
+    
     template "/etc/init/tomcat_#{new_resource.instance_name}.conf" do
       source 'init_upstart.erb'
       sensitive new_resource.sensitive


### PR DESCRIPTION
### Description

Adding missing setenv.sh on centos7 (systemd) and ubuntu (upstart) systems.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
