### PR TITLE
WIP: Adds support for Windows

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,6 +23,12 @@ platforms:
   - name: debian-10
   - name: ubuntu-18.04
   - name: ubuntu-20.04
+  - name: windows2016
+    driver_config:
+      box: tas50/windows_2016
+  - name: windows2019
+    driver_config:
+      box: tas50/windows_2019
 
 suites:
   - name: checksum_examples

--- a/libraries/install_helpers.rb
+++ b/libraries/install_helpers.rb
@@ -1,0 +1,179 @@
+module TomcatCookbook
+  module InstallHelpers
+    # break apart the version string to find the major version
+    def major_version(version)
+      @major_version ||= version.split('.')[0]
+    end
+
+    def default_tomcat_install_path(instance_name, version)
+      if platform?('windows')
+        "C:/tomcat_#{instance_name}_#{version.tr('.', '_')}/"
+      else
+        "/opt/tomcat_#{instance_name}_#{version.tr('.', '_')}/"
+      end
+    end
+
+    def default_tomcat_symlink_path(instance_name)
+      if platform?('windows')
+        "C:/tomcat_#{instance_name}"
+      else
+        "/opt/tomcat_#{instance_name}"
+      end
+    end
+
+    def default_tomcat_archive_uri(base_uri, version, version_archive)
+      URI.join(base_uri, "tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}").to_s
+    end
+
+    # returns the URI of the apache.org generated checksum based on either
+    # an absolute path to the tarball or the tarball based path.
+    def default_tomcat_checksum_uri(base_uri, version, version_archive)
+      URI.join(base_uri, "tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}.#{version_checksum_algorithm(version)}").to_s
+    end
+
+    # Apache started using sha512 (replacing md5) in these versions and now
+    # only publishes sha512 checksums
+    def version_checksum_algorithm(version)
+      case Gem::Version.new(version)
+      when -> (v) { Gem::Requirement.new('~> 7.0.84').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 8.0.48').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 8.5.24').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 9.0.10').satisfied_by?(v) }
+        'sha512'
+      else
+        'md5'
+      end
+    end
+
+    # Get the archive name
+    def tomcat_archive_name(version)
+      if platform?('windows')
+        case node['kernel']['machine']
+        when 'i386'
+          windows_architecture = 'x86'
+        when 'x86_64'
+          windows_architecture = 'x64'
+        end
+
+        "apache-tomcat-#{version}-windows-#{windows_architecture}.zip"
+      else
+        "apache-tomcat-#{version}.tar.gz"
+      end
+    end
+
+    # build the extraction command based on the passed properties
+    def tomcat_extraction_command(version, install_path, archive_path, exclude_examples, exclude_docs, exclude_manager, exclude_hostmanager)
+      if platform?('windows')
+        # Powershell's built-in `Expand-Archive` doesn't allow excluding directories like tar
+        # Also, the Windows archive has a nested `apache-tomcat-<version>` folder inside of the zip
+        cmd = <<-EOH
+          # Inputs
+          $destination = '#{install_path}'
+          $version = '#{version}'
+
+          $archivePath = '#{archive_path}'
+
+          $excludeExamples = $#{exclude_examples}
+          $excludeDocs = $#{exclude_docs}
+          $excludeManager = $#{exclude_manager}
+          $excludeHostManager = $#{exclude_hostmanager}
+
+          # Core Script
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+          $excludedRegexPaths = New-Object System.Collections.Generic.List[String]
+
+          # Exclude the empty top level entry
+          $excludedRegexPaths.Add("apache-tomcat-$version/$")
+
+          # Exclude the temp file in the temp dir
+          $excludedRegexPaths.Add("apache-tomcat-$version/temp/safeToDelete.tmp")
+
+          if($excludeExamples){
+              $excludedRegexPaths.Add('.*webapps\/examples.*')
+              $excludedRegexPaths.Add('.*webapps\/ROOT.*')
+          }
+
+          if($excludeDocs){
+              $excludedRegexPaths.Add('.*webapps\/docs.*')
+          }
+
+          if($excludeManager){
+              $excludedRegexPaths.Add('.*webapps\/manager.*')
+          }
+
+          if($excludeHostManager){
+              $excludedRegexPaths.Add('.*webapps\/host-manager.*')
+          }
+
+          # Take the excluded paths and build one big regex for it
+          $regexPattern = $($excludedRegexPaths -join '|')
+
+          $archive = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
+
+          foreach($entry in $archive.entries | Where-Object {$_.FullName -NotMatch $regexPattern}){
+            # Build the destination file path; stripping out the apache-tomcat-version/ that exists on the entries
+            $destinationPath = Join-Path -Path $destination -ChildPath $entry.FullName.Replace("apache-tomcat-$version/",'')
+
+            # If the path ends with a slash, then create the directory, otherwise extract the zip entry
+            if($entry.FullName.EndsWith('/')){
+              New-Item -Path $destinationPath -ItemType Directory | Out-Null
+            }else{
+              [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $destinationPath)
+            }
+          }
+
+          $archive.Dispose()
+        EOH
+      else
+        cmd = "tar -xzf #{archive_path} -C #{install_path} --strip-components=1"
+        cmd << " --exclude='*webapps/examples*'" if exclude_examples
+        cmd << " --exclude='*webapps/ROOT*'" if exclude_examples
+        cmd << " --exclude='*webapps/docs*'" if exclude_docs
+        cmd << " --exclude='*webapps/manager*'" if exclude_manager
+        cmd << " --exclude='*webapps/host-manager*'" if exclude_hostmanager
+      end
+
+      cmd
+    end
+
+    # fetch the md5 checksum from the mirrors
+    # we have to do this since the md5 chef expects isn't hosted
+    def fetch_tomcat_checksum(checksum_uri, validate_ssl)
+      uri = URI(checksum_uri)
+      request = Net::HTTP.new(uri.host, uri.port)
+      if uri.to_s.start_with?('https')
+        request.use_ssl = true
+        request.verify_mode = OpenSSL::SSL::VERIFY_NONE unless validate_ssl
+      end
+      response = request.get(uri)
+      if response.code != '200'
+        Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
+        raise
+      end
+      response.body.split(' ')[0]
+    rescue => e
+      Chef::Log.fatal("Could not fetch the checksum due to an error: #{e}")
+      raise
+    end
+
+    # validate the mirror checksum against the on disk checksum
+    # return true if they match. Append .bad to the cached copy to prevent using it next time
+    def validate_tomcat_checksum(file_to_check, version, checksum_uri, validate_ssl)
+      desired = fetch_tomcat_checksum(checksum_uri, validate_ssl)
+      klass = Object.const_get("Digest::#{version_checksum_algorithm(version).upcase}")
+      actual = klass.hexdigest(::File.read(file_to_check, mode: 'rb'))
+
+      if desired == actual
+        true
+      else
+        Chef::Log.fatal("The checksum of the tomcat tarball on disk (#{actual}) does not match the checksum provided from the mirror (#{desired}). Renaming to #{::File.basename(file_to_check)}.bad")
+        ::File.rename(file_to_check, "#{file_to_check}.bad")
+        raise
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ issues_url        'https://github.com/sous-chefs/tomcat/issues'
 chef_version      '>= 13'
 version           '3.4.0'
 
-%w(ubuntu debian redhat centos suse opensuseleap scientific oracle amazon zlinux).each do |os|
+%w(ubuntu debian redhat centos suse opensuseleap scientific oracle amazon zlinux windows).each do |os|
   supports os
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,9 +17,12 @@
 # limitations under the License.
 #
 
+include TomcatCookbook::InstallHelpers
+
 property :instance_name, String, name_property: true
-property :version, String, default: '8.5.54'
-property :install_path, String, default: lazy { |r| "/opt/tomcat_#{r.instance_name}_#{r.version.tr('.', '_')}/" }
+property :version, String, default: '8.5.54', regex: /^\d+.\d+.\d+$/
+property :version_archive, String, default: lazy { tomcat_archive_name(version) }
+property :install_path, String, default: lazy { default_tomcat_install_path(instance_name, version) }
 property :tarball_base_uri, String, default: 'http://archive.apache.org/dist/tomcat/', desired_state: false
 property :checksum_base_uri, String, default: 'http://archive.apache.org/dist/tomcat/', desired_state: false
 property :verify_checksum, [true, false], default: true, desired_state: false
@@ -28,169 +31,99 @@ property :exclude_docs, [true, false], default: true, desired_state: false
 property :exclude_examples, [true, false], default: true, desired_state: false
 property :exclude_manager, [true, false], default: false, desired_state: false
 property :exclude_hostmanager, [true, false], default: false, desired_state: false
-property :tarball_uri, String, default: '', desired_state: false
-property :tarball_path, String, default: lazy { |r| "#{Chef::Config['file_cache_path']}/apache-tomcat-#{r.version}.tar.gz" }, desired_state: false
+property :tarball_uri, String, default: lazy { default_tomcat_archive_uri(tarball_base_uri, version, version_archive) }, desired_state: false
+property :checksum_uri, String, default: lazy { default_tomcat_checksum_uri(checksum_base_uri, version, version_archive) }, desired_state: false
+property :tarball_path, String, default: lazy { |r| "#{Chef::Config['file_cache_path']}/#{r.version_archive}" }, desired_state: false
 property :tarball_validate_ssl, [true, false], default: true, desired_state: false
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_user_shell, String, default: '/bin/false'
 property :create_user, [true, false], default: true, desired_state: false
 property :create_group, [true, false], default: true, desired_state: false
+property :create_symlink, [true, false], default: true, desired_state: false
+property :symlink_path, String, default: lazy { default_tomcat_symlink_path(instance_name) }, desired_state: false
 
 action :install do
-  validate_version
-
   # Support file:// uri moniker but short-circuit into a better pattern.
   new_resource.tarball_path = new_resource.tarball_uri.sub(%r{^file://}, '') if new_resource.tarball_uri.start_with?('file://')
 
-  # some RHEL systems lack tar in their minimal install
-  package %w(tar gzip)
+  if platform?('windows')
+    directory 'tomcat install dir' do
+      path new_resource.install_path
+      recursive true
+    end
 
-  group new_resource.tomcat_group do
-    action :create
-    append true
-    only_if { new_resource.create_group }
-  end
+    remote_file "apache #{new_resource.version} zip" do
+      source new_resource.tarball_uri
+      path new_resource.tarball_path
+      verify { |file| validate_tomcat_checksum(file, new_resource.version, new_resource.checksum_uri, new_resource.tarball_validate_ssl) } if new_resource.verify_checksum
+      # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
+      not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
+    end
 
-  user new_resource.tomcat_user do
-    gid new_resource.tomcat_group
-    shell new_resource.tomcat_user_shell
-    system true
-    action :create
-    only_if { new_resource.create_user }
-  end
+    powershell_script 'extract tomcat zip' do
+      code generate_extraction_command
+      action :run
+      creates ::File.join(new_resource.install_path, 'LICENSE')
+    end
+  else
+    # some RHEL systems lack tar in their minimal install
+    package %w(tar gzip)
 
-  directory 'tomcat install dir' do
-    mode new_resource.dir_mode.to_s
-    path new_resource.install_path
-    recursive true
-    owner new_resource.tomcat_user
-    group new_resource.tomcat_group
-  end
+    group new_resource.tomcat_group do
+      action :create
+      append true
+      only_if { new_resource.create_group }
+    end
 
-  remote_file "apache #{new_resource.version} tarball" do
-    source tarball_uri
-    path new_resource.tarball_path
-    verify { |file| validate_checksum(file) } if new_resource.verify_checksum
-    # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
-    not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
-  end
+    user new_resource.tomcat_user do
+      gid new_resource.tomcat_group
+      shell new_resource.tomcat_user_shell
+      system true
+      action :create
+      only_if { new_resource.create_user }
+    end
 
-  execute 'extract tomcat tarball' do
-    command extraction_command
-    action :run
-    creates ::File.join(new_resource.install_path, 'LICENSE')
-  end
+    directory 'tomcat install dir' do
+      mode new_resource.dir_mode.to_s
+      path new_resource.install_path
+      recursive true
+      owner new_resource.tomcat_user
+      group new_resource.tomcat_group
+    end
 
-  # make sure the instance's user owns the instance install dir
-  execute "chown install dir as tomcat_#{new_resource.instance_name}" do
-    command "chown -R #{new_resource.tomcat_user}:#{new_resource.tomcat_group} #{new_resource.install_path}"
-    action :run
-    not_if { Etc.getpwuid(::File.stat("#{new_resource.install_path}/LICENSE").uid).name == new_resource.tomcat_user }
+    remote_file "apache #{new_resource.version} tarball" do
+      source new_resource.tarball_uri
+      path new_resource.tarball_path
+      verify { |file| validate_checksum(file) } if new_resource.verify_checksum
+      # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
+      not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
+    end
+
+    execute 'extract tomcat tarball' do
+      command generate_extraction_command
+      action :run
+      creates ::File.join(new_resource.install_path, 'LICENSE')
+    end
+
+    # make sure the instance's user owns the instance install dir
+    execute "chown install dir as tomcat_#{new_resource.instance_name}" do
+      command "chown -R #{new_resource.tomcat_user}:#{new_resource.tomcat_group} #{new_resource.install_path}"
+      action :run
+      not_if { Etc.getpwuid(::File.stat("#{new_resource.install_path}/LICENSE").uid).name == new_resource.tomcat_user }
+    end
   end
 
   # create a link that points to the latest version of the instance
-  link "/opt/tomcat_#{new_resource.instance_name}" do
+  link new_resource.symlink_path.to_s do
     to new_resource.install_path
+    only_if { new_resource.create_symlink }
   end
 end
 
 action_class do
-  # break apart the version string to find the major version
-  def major_version
-    @major_version ||= new_resource.version.split('.')[0]
-  end
-
-  # build the extraction command based on the passed properties
-  def extraction_command
-    cmd = "tar -xzf #{new_resource.tarball_path} -C #{new_resource.install_path} --strip-components=1"
-    cmd << " --exclude='*webapps/examples*'" if new_resource.exclude_examples
-    cmd << " --exclude='*webapps/ROOT*'" if new_resource.exclude_examples
-    cmd << " --exclude='*webapps/docs*'" if new_resource.exclude_docs
-    cmd << " --exclude='*webapps/manager*'" if new_resource.exclude_manager
-    cmd << " --exclude='*webapps/host-manager*'" if new_resource.exclude_hostmanager
-    cmd
-  end
-
-  # ensure the version is X.Y.Z format
-  def validate_version
-    return if new_resource.version =~ /\d+.\d+.\d+/
-    Chef::Log.fatal("The version must be in X.Y.Z format. Passed value: #{new_resource.version}")
-    raise
-  end
-
-  # returns the URI of the apache.org generated checksum based on either
-  # an absolute path to the tarball or the tarball based path.
-  def checksum_uri(sum_form)
-    if new_resource.tarball_uri.empty?
-      URI.join(new_resource.checksum_base_uri, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.#{sum_form}")
-    else
-      URI("#{new_resource.tarball_uri}.#{sum_form}")
-    end
-  end
-
-  # fetch the md5 checksum from the mirrors
-  # we have to do this since the md5 chef expects isn't hosted
-  def fetch_checksum(form)
-    uri = checksum_uri(form)
-    request = Net::HTTP.new(uri.host, uri.port)
-    if uri.to_s.start_with?('https')
-      request.use_ssl = true
-      request.verify_mode = OpenSSL::SSL::VERIFY_NONE unless new_resource.tarball_validate_ssl
-    end
-    response = request.get(uri)
-    if response.code != '200'
-      Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
-      raise
-    end
-    response.body.split(' ')[0]
-  rescue => e
-    Chef::Log.fatal("Could not fetch the checksum due to an error: #{e}")
-    raise
-  end
-
-  # validate the mirror checksum against the on disk checksum
-  # return true if they match. Append .bad to the cached copy to prevent using it next time
-  def validate_checksum(file_to_check)
-    # Apache started using sha512 (replacing md5) in these versions and now
-    # only publishes sha512 checksums
-    sum_form = case Gem::Version.new(new_resource.version)
-               when -> (v) { Gem::Requirement.new('~> 7.0.84').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 8.0.48').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 8.5.24').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 9.0.10').satisfied_by?(v) }
-                 'sha512'
-               else
-                 'md5'
-               end
-
-    desired = fetch_checksum(sum_form)
-    klass = Object.const_get("Digest::#{sum_form.upcase}")
-    actual = klass.hexdigest(::File.read(file_to_check))
-
-    if desired == actual
-      true
-    else
-      Chef::Log.fatal("The checksum of the tomcat tarball on disk (#{actual}) does not match the checksum provided from the mirror (#{desired}). Renaming to #{::File.basename(file_to_check)}.bad")
-      ::File.rename(file_to_check, "#{file_to_check}.bad")
-      raise
-    end
-  end
-
-  # build the complete tarball URI and handle basepath with/without trailing /
-  def tarball_uri
-    uri = ''
-    if new_resource.tarball_uri.empty?
-      uri << new_resource.tarball_base_uri
-      uri << '/' unless uri[-1] == '/'
-      uri << "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz"
-    else
-      uri << new_resource.tarball_uri
-    end
-    uri
+  def generate_extraction_command
+    tomcat_extraction_command(new_resource.version, new_resource.install_path, new_resource.tarball_path, new_resource.exclude_examples, new_resource.exclude_docs, new_resource.exclude_manager, new_resource.exclude_hostmanager)
   end
 end
 

--- a/test/cookbooks/test/recipes/windows.rb
+++ b/test/cookbooks/test/recipes/windows.rb
@@ -1,0 +1,5 @@
+instance_name = 'windows'
+
+tomcat_install instance_name do
+  version '9.0.36'
+end


### PR DESCRIPTION
# Description

- Adds support for `tomcat_install` on Windows
- Externalize install helpers to a library so wrapper cookbooks could utilize
- Adds helper libraries to extract values between platforms
- Adds `create_symlink` and `symlink_path` properties

# Questions

- With Windows archives being .zip, I don't love the `tarball` properties. Any concerns with changing them to `archive` and adding aliases?
- As I start to look at the Windows Service components, it's likely going to be a bit involved with abstractions around `prunsrv.exe` (Apache Commons Daemon) for the interactions. I feel like it would make sense for those abstractions to live within their own cookbook since they have use outside of just Tomcat and a dependency added, any concerns with that?

## Issues Resolved

#340 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
