### PR TITLE
`tomcat_install` refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the tomcat cookbook.
 
+## 3.5.0 (2020-09-10)
+
+- Adds `create_symlink` property to `tomcat_install` to allow opting out of creation - [@jakauppila](https://github.com/jakauppila)
+- Adds `symlink_path` property to `tomcat_install` to customize symlink path - [@jakauppila](https://github.com/jakauppila)
+- Moved `tomcat_install` functions to library and added tests - [@jakauppila](https://github.com/jakauppila)
+
 ## 3.4.0 (2020-05-06)
 
 - Sync platforms in kitchen w/ Github Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the tomcat cookbook.
 
-## 3.5.0 (2020-09-10)
+## Unreleased
 
 - Adds `create_symlink` property to `tomcat_install` to allow opting out of creation - [@jakauppila](https://github.com/jakauppila)
 - Adds `symlink_path` property to `tomcat_install` to customize symlink path - [@jakauppila](https://github.com/jakauppila)

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 #### properties
 
 - `version`: The version to install. Default: 8.5.54
-- `install_path`: Full path to the install directory. Default: /opt/tomcat_INSTANCENAME_VERSION
-- `tarball_base_uri`: The base uri to the apache mirror containing the tarballs. Default: '<http://archive.apache.org/dist/tomcat/>'
+- `version_archive`: The filename of the versioned archive to install. Default: apache-tomcat-VERSION.tar.gz
+- `install_path`: Full path to the install directory. Default: `/opt/tomcat_INSTANCENAME_VERSION`
+- `tarball_base_uri`: The base uri to the apache mirror containing the tarballs. Default: `<http://archive.apache.org/dist/tomcat/>'
 - `checksum_base_uri`: The base uri to the apache mirror containing the md5 or sha512 file. Default: '<http://archive.apache.org/dist/tomcat/>'
 - `verify_checksum`: Whether the checksum should be verified against `checksum_base_uri`. Default: `true`.
 - `dir_mode`: Directory permissions of the `install_path`. Default: `'0750'`.
-- `tarball_uri`: The complete uri to the tarball. If specified would override (`tarball_base_uri` and `checksum_base_uri`). checksum will be loaded from "#{tarball_uri}.{md5,sha512}". This attribute is useful, if you are hosting tomcat tarballs from artifact repositories such as nexus. `sha512` sums are used for version constraints: `~> 7.0.84`, `~> 8.0.48`, `~> 8.5.24`, `~> 9.0.10`.
+- `tarball_uri`: The complete uri to the tarball. Default: `TARBALL_BASE_URI/tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}.#{version_checksum_algorithm(version)}`
+- `checksum_uri`: The complete uri to the tarball checksum. Default: `CHECKSUM_BASE_URI/tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}.#{version_checksum_algorithm(version)}`
 - `tarball_path`: Local path on disk to the tarball. If the file does not exist, or the checksum does not match, it will be downloaded from `tarball_uri`.
 - `tarball_validate_ssl`: Validate the SSL certificate, if `tarball_uri` is using HTTPS. Default `true`.
 - `exclude_docs`: Exclude ./webapps/docs from installation. Default `true`.
@@ -55,10 +57,12 @@ tomcat_install installs an instance of the tomcat binary direct from Apache's mi
 - `tomcat_user_shell`: Shell of the tomcat user. Default: `/bin/false`
 - `create_user`: Creates the specified tomcat_user within the OS.  Default `true`.
 - `create_group`: Creates the specified tomcat_group within the OS. Default `true`.
-- `service_template_source`: Source template file for the sys-v/upstart/systemd service definition. Default: 'init_sysv.erb'
-- `service_template_cookbook`: Cookbook from which to source the sys-v/upstart/systemd service definition template. Default: 'tomcat'
-- `setenv_template_source`: Source template file for the sys-v 'setenv' file. Default: 'setenv.erb'
-- `setenv_template_cookbook`: Cookbook from which to source the sys-v 'setenv' file. Default: 'tomcat'
+- `service_template_source`: Source template file for the sys-v/upstart/systemd service definition. Default: `init_sysv.erb`
+- `service_template_cookbook`: Cookbook from which to source the sys-v/upstart/systemd service definition template. Default: `tomcat`
+- `setenv_template_source`: Source template file for the sys-v 'setenv' file. Default: `setenv.erb`
+- `setenv_template_cookbook`: Cookbook from which to source the sys-v 'setenv' file. Default: `tomcat`
+- `create_symlink`: Creates symlink at SYMLINK_PATH to INSTALL_PATH. Default: `true`
+- `symlink_path`: Full path to where the symlink will be created targetting INSTALL_PATH. Default: `/opt/tomcat_INSTANCE_NAME`
 
 #### example
 

--- a/libraries/install_helpers.rb
+++ b/libraries/install_helpers.rb
@@ -1,0 +1,84 @@
+module TomcatCookbook
+  module InstallHelpers
+    # break apart the version string to find the major version
+    def major_version(version)
+      @major_version ||= version.split('.')[0]
+    end
+
+    def default_tomcat_install_path(instance_name, version)
+      "/opt/tomcat_#{instance_name}_#{version.tr('.', '_')}/"
+    end
+
+    def default_tomcat_symlink_path(instance_name)
+      "/opt/tomcat_#{instance_name}"
+    end
+
+    def default_tomcat_archive_uri(base_uri, version, version_archive)
+      URI.join(base_uri, "tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}").to_s
+    end
+
+    # returns the URI of the apache.org generated checksum based on either
+    # an absolute path to the tarball or the tarball based path.
+    def default_tomcat_checksum_uri(base_uri, version, version_archive)
+      URI.join(base_uri, "tomcat-#{major_version(version)}/v#{version}/bin/#{version_archive}.#{version_checksum_algorithm(version)}").to_s
+    end
+
+    # Apache started using sha512 (replacing md5) in these versions and now
+    # only publishes sha512 checksums
+    def version_checksum_algorithm(version)
+      case Gem::Version.new(version)
+      when -> (v) { Gem::Requirement.new('~> 7.0.84').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 8.0.48').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 8.5.24').satisfied_by?(v) }
+        'sha512'
+      when -> (v) { Gem::Requirement.new('~> 9.0.10').satisfied_by?(v) }
+        'sha512'
+      else
+        'md5'
+      end
+    end
+
+    # Get the archive name
+    def tomcat_archive_name(version)
+      "apache-tomcat-#{version}.tar.gz"
+    end
+
+    # fetch the md5 checksum from the mirrors
+    # we have to do this since the md5 chef expects isn't hosted
+    def fetch_tomcat_checksum(checksum_uri, validate_ssl)
+      uri = URI(checksum_uri)
+      request = Net::HTTP.new(uri.host, uri.port)
+      if uri.to_s.start_with?('https')
+        request.use_ssl = true
+        request.verify_mode = OpenSSL::SSL::VERIFY_NONE unless validate_ssl
+      end
+      response = request.get(uri)
+      if response.code != '200'
+        Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
+        raise
+      end
+      response.body.split(' ')[0]
+    rescue => e
+      Chef::Log.fatal("Could not fetch the checksum due to an error: #{e}")
+      raise
+    end
+
+    # validate the mirror checksum against the on disk checksum
+    # return true if they match. Append .bad to the cached copy to prevent using it next time
+    def validate_tomcat_checksum(file_to_check, version, checksum_uri, validate_ssl)
+      desired = fetch_tomcat_checksum(checksum_uri, validate_ssl)
+      klass = Object.const_get("Digest::#{version_checksum_algorithm(version).upcase}")
+      actual = klass.hexdigest(::File.read(file_to_check, mode: 'rb'))
+
+      if desired == actual
+        true
+      else
+        Chef::Log.fatal("The checksum of the tomcat tarball on disk (#{actual}) does not match the checksum provided from the mirror (#{desired}). Renaming to #{::File.basename(file_to_check)}.bad")
+        ::File.rename(file_to_check, "#{file_to_check}.bad")
+        raise
+      end
+    end
+  end
+end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,9 +17,12 @@
 # limitations under the License.
 #
 
+include TomcatCookbook::InstallHelpers
+
 property :instance_name, String, name_property: true
-property :version, String, default: '8.5.54'
-property :install_path, String, default: lazy { |r| "/opt/tomcat_#{r.instance_name}_#{r.version.tr('.', '_')}/" }
+property :version, String, default: '8.5.54', regex: /^\d+.\d+.\d+$/
+property :version_archive, String, default: lazy { tomcat_archive_name(version) }
+property :install_path, String, default: lazy { default_tomcat_install_path(instance_name, version) }
 property :tarball_base_uri, String, default: 'http://archive.apache.org/dist/tomcat/', desired_state: false
 property :checksum_base_uri, String, default: 'http://archive.apache.org/dist/tomcat/', desired_state: false
 property :verify_checksum, [true, false], default: true, desired_state: false
@@ -28,79 +31,97 @@ property :exclude_docs, [true, false], default: true, desired_state: false
 property :exclude_examples, [true, false], default: true, desired_state: false
 property :exclude_manager, [true, false], default: false, desired_state: false
 property :exclude_hostmanager, [true, false], default: false, desired_state: false
-property :tarball_uri, String, default: '', desired_state: false
-property :tarball_path, String, default: lazy { |r| "#{Chef::Config['file_cache_path']}/apache-tomcat-#{r.version}.tar.gz" }, desired_state: false
+property :tarball_uri, String, default: lazy { default_tomcat_archive_uri(tarball_base_uri, version, version_archive) }, desired_state: false
+property :checksum_uri, String, default: lazy { default_tomcat_checksum_uri(checksum_base_uri, version, version_archive) }, desired_state: false
+property :tarball_path, String, default: lazy { |r| "#{Chef::Config['file_cache_path']}/#{r.version_archive}" }, desired_state: false
 property :tarball_validate_ssl, [true, false], default: true, desired_state: false
 property :tomcat_user, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_group, String, default: lazy { |r| "tomcat_#{r.instance_name}" }
 property :tomcat_user_shell, String, default: '/bin/false'
 property :create_user, [true, false], default: true, desired_state: false
 property :create_group, [true, false], default: true, desired_state: false
+property :create_symlink, [true, false], default: true, desired_state: false
+property :symlink_path, String, default: lazy { default_tomcat_symlink_path(instance_name) }, desired_state: false
 
 action :install do
-  validate_version
-
   # Support file:// uri moniker but short-circuit into a better pattern.
   new_resource.tarball_path = new_resource.tarball_uri.sub(%r{^file://}, '') if new_resource.tarball_uri.start_with?('file://')
 
-  # some RHEL systems lack tar in their minimal install
-  package %w(tar gzip)
+  if platform?('windows')
+    directory 'tomcat install dir' do
+      path new_resource.install_path
+      recursive true
+    end
 
-  group new_resource.tomcat_group do
-    action :create
-    append true
-    only_if { new_resource.create_group }
-  end
+    remote_file "apache #{new_resource.version} zip" do
+      source new_resource.tarball_uri
+      path new_resource.tarball_path
+      verify { |file| validate_tomcat_checksum(file, new_resource.version, new_resource.checksum_uri, new_resource.tarball_validate_ssl) } if new_resource.verify_checksum
+      # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
+      not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
+    end
 
-  user new_resource.tomcat_user do
-    gid new_resource.tomcat_group
-    shell new_resource.tomcat_user_shell
-    system true
-    action :create
-    only_if { new_resource.create_user }
-  end
+    powershell_script 'extract tomcat zip' do
+      code generate_extraction_command
+      action :run
+      creates ::File.join(new_resource.install_path, 'LICENSE')
+    end
+  else
+    # some RHEL systems lack tar in their minimal install
+    package %w(tar gzip)
 
-  directory 'tomcat install dir' do
-    mode new_resource.dir_mode.to_s
-    path new_resource.install_path
-    recursive true
-    owner new_resource.tomcat_user
-    group new_resource.tomcat_group
-  end
+    group new_resource.tomcat_group do
+      action :create
+      append true
+      only_if { new_resource.create_group }
+    end
 
-  remote_file "apache #{new_resource.version} tarball" do
-    source tarball_uri
-    path new_resource.tarball_path
-    verify { |file| validate_checksum(file) } if new_resource.verify_checksum
-    # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
-    not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
-  end
+    user new_resource.tomcat_user do
+      gid new_resource.tomcat_group
+      shell new_resource.tomcat_user_shell
+      system true
+      action :create
+      only_if { new_resource.create_user }
+    end
 
-  execute 'extract tomcat tarball' do
-    command extraction_command
-    action :run
-    creates ::File.join(new_resource.install_path, 'LICENSE')
-  end
+    directory 'tomcat install dir' do
+      mode new_resource.dir_mode.to_s
+      path new_resource.install_path
+      recursive true
+      owner new_resource.tomcat_user
+      group new_resource.tomcat_group
+    end
 
-  # make sure the instance's user owns the instance install dir
-  execute "chown install dir as tomcat_#{new_resource.instance_name}" do
-    command "chown -R #{new_resource.tomcat_user}:#{new_resource.tomcat_group} #{new_resource.install_path}"
-    action :run
-    not_if { Etc.getpwuid(::File.stat("#{new_resource.install_path}/LICENSE").uid).name == new_resource.tomcat_user }
+    remote_file "apache #{new_resource.version} tarball" do
+      source new_resource.tarball_uri
+      path new_resource.tarball_path
+      verify { |file| validate_tomcat_checksum(file, new_resource.version, new_resource.checksum_uri, new_resource.tarball_validate_ssl) } if new_resource.verify_checksum
+      # If a file already exists at the path specified, and we skip checksum verification, then we can assume that the file was laid down by the user.
+      not_if { ::File.exist?(new_resource.tarball_path) } unless new_resource.verify_checksum
+    end
+
+    execute 'extract tomcat tarball' do
+      command extraction_command
+      action :run
+      creates ::File.join(new_resource.install_path, 'LICENSE')
+    end
+
+    # make sure the instance's user owns the instance install dir
+    execute "chown install dir as tomcat_#{new_resource.instance_name}" do
+      command "chown -R #{new_resource.tomcat_user}:#{new_resource.tomcat_group} #{new_resource.install_path}"
+      action :run
+      not_if { Etc.getpwuid(::File.stat("#{new_resource.install_path}/LICENSE").uid).name == new_resource.tomcat_user }
+    end
   end
 
   # create a link that points to the latest version of the instance
-  link "/opt/tomcat_#{new_resource.instance_name}" do
+  link new_resource.symlink_path.to_s do
     to new_resource.install_path
+    only_if { new_resource.create_symlink }
   end
 end
 
 action_class do
-  # break apart the version string to find the major version
-  def major_version
-    @major_version ||= new_resource.version.split('.')[0]
-  end
-
   # build the extraction command based on the passed properties
   def extraction_command
     cmd = "tar -xzf #{new_resource.tarball_path} -C #{new_resource.install_path} --strip-components=1"
@@ -110,87 +131,6 @@ action_class do
     cmd << " --exclude='*webapps/manager*'" if new_resource.exclude_manager
     cmd << " --exclude='*webapps/host-manager*'" if new_resource.exclude_hostmanager
     cmd
-  end
-
-  # ensure the version is X.Y.Z format
-  def validate_version
-    return if new_resource.version =~ /\d+.\d+.\d+/
-    Chef::Log.fatal("The version must be in X.Y.Z format. Passed value: #{new_resource.version}")
-    raise
-  end
-
-  # returns the URI of the apache.org generated checksum based on either
-  # an absolute path to the tarball or the tarball based path.
-  def checksum_uri(sum_form)
-    if new_resource.tarball_uri.empty?
-      URI.join(new_resource.checksum_base_uri, "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz.#{sum_form}")
-    else
-      URI("#{new_resource.tarball_uri}.#{sum_form}")
-    end
-  end
-
-  # fetch the md5 checksum from the mirrors
-  # we have to do this since the md5 chef expects isn't hosted
-  def fetch_checksum(form)
-    uri = checksum_uri(form)
-    request = Net::HTTP.new(uri.host, uri.port)
-    if uri.to_s.start_with?('https')
-      request.use_ssl = true
-      request.verify_mode = OpenSSL::SSL::VERIFY_NONE unless new_resource.tarball_validate_ssl
-    end
-    response = request.get(uri)
-    if response.code != '200'
-      Chef::Log.fatal("Fetching the Tomcat tarball checksum at #{uri} resulted in an error #{response.code}")
-      raise
-    end
-    response.body.split(' ')[0]
-  rescue => e
-    Chef::Log.fatal("Could not fetch the checksum due to an error: #{e}")
-    raise
-  end
-
-  # validate the mirror checksum against the on disk checksum
-  # return true if they match. Append .bad to the cached copy to prevent using it next time
-  def validate_checksum(file_to_check)
-    # Apache started using sha512 (replacing md5) in these versions and now
-    # only publishes sha512 checksums
-    sum_form = case Gem::Version.new(new_resource.version)
-               when -> (v) { Gem::Requirement.new('~> 7.0.84').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 8.0.48').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 8.5.24').satisfied_by?(v) }
-                 'sha512'
-               when -> (v) { Gem::Requirement.new('~> 9.0.10').satisfied_by?(v) }
-                 'sha512'
-               else
-                 'md5'
-               end
-
-    desired = fetch_checksum(sum_form)
-    klass = Object.const_get("Digest::#{sum_form.upcase}")
-    actual = klass.hexdigest(::File.read(file_to_check))
-
-    if desired == actual
-      true
-    else
-      Chef::Log.fatal("The checksum of the tomcat tarball on disk (#{actual}) does not match the checksum provided from the mirror (#{desired}). Renaming to #{::File.basename(file_to_check)}.bad")
-      ::File.rename(file_to_check, "#{file_to_check}.bad")
-      raise
-    end
-  end
-
-  # build the complete tarball URI and handle basepath with/without trailing /
-  def tarball_uri
-    uri = ''
-    if new_resource.tarball_uri.empty?
-      uri << new_resource.tarball_base_uri
-      uri << '/' unless uri[-1] == '/'
-      uri << "tomcat-#{major_version}/v#{new_resource.version}/bin/apache-tomcat-#{new_resource.version}.tar.gz"
-    else
-      uri << new_resource.tarball_uri
-    end
-    uri
   end
 end
 

--- a/spec/libraries/install_helpers_spec.rb
+++ b/spec/libraries/install_helpers_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+RSpec.describe TomcatCookbook::InstallHelpers do
+  class DummyClass < Chef::Node
+    include TomcatCookbook::InstallHelpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#major_version' do
+    context 'Version 8' do
+      let(:version) { '8' }
+
+      it 'returns the correct major version' do
+        expect(subject.major_version(version)).to eq '8'
+      end
+    end
+
+    context 'Version 11.0.8.10.1' do
+      let(:version) { '11.0.8.10.1' }
+
+      it 'returns the correct major version' do
+        expect(subject.major_version(version)).to eq '11'
+      end
+    end
+  end
+
+  describe '#default_tomcat_install_path' do
+    context 'helloworld 9.0.37' do
+      let(:instance_name) { 'helloworld' }
+      let(:version) { '9.0.37' }
+
+      it 'returns the correct path' do
+        expect(subject.default_tomcat_install_path(instance_name, version)).to eq '/opt/tomcat_helloworld_9_0_37/'
+      end
+    end
+  end
+
+  describe '#default_tomcat_symlink_path' do
+    context 'helloworld' do
+      let(:instance_name) { 'helloworld' }
+
+      it 'returns the correct path' do
+        expect(subject.default_tomcat_symlink_path(instance_name)).to eq '/opt/tomcat_helloworld'
+      end
+    end
+  end
+
+  describe '#default_tomcat_archive_uri' do
+    context '9.0.37' do
+      let(:base_uri) { 'http://archive.apache.org/dist/tomcat/' }
+      let(:version) { '9.0.37' }
+      let(:version_archive) { 'apache-tomcat-9.0.37.tar.gz' }
+
+      it 'returns the correct uri' do
+        expect(subject.default_tomcat_archive_uri(base_uri, version, version_archive)).to eq 'http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.37/bin/apache-tomcat-9.0.37.tar.gz'
+      end
+    end
+  end
+
+  describe '#default_tomcat_checksum_uri' do
+    context '9.0.37' do
+      let(:base_uri) { 'http://archive.apache.org/dist/tomcat/' }
+      let(:version) { '9.0.37' }
+      let(:version_archive) { 'apache-tomcat-9.0.37.tar.gz' }
+
+      it 'returns the correct uri' do
+        expect(subject.default_tomcat_checksum_uri(base_uri, version, version_archive)).to eq 'http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.37/bin/apache-tomcat-9.0.37.tar.gz.sha512'
+      end
+    end
+  end
+
+  describe '#version_checksum_algorithm' do
+    context '6.0.53' do
+      let(:version) { '6.0.53' }
+
+      it 'returns the correct checksum algorithm' do
+        expect(subject.version_checksum_algorithm(version)).to eq 'md5'
+      end
+    end
+
+    context '9.0.37' do
+      let(:version) { '9.0.37' }
+
+      it 'returns the correct uri' do
+        expect(subject.version_checksum_algorithm(version)).to eq 'sha512'
+      end
+    end
+  end
+
+  describe '#tomcat_archive_name' do
+    context '9.0.37' do
+      let(:version) { '9.0.37' }
+
+      it 'returns the correct archive name' do
+        expect(subject.tomcat_archive_name(version)).to eq 'apache-tomcat-9.0.37.tar.gz'
+      end
+    end
+  end
+end

--- a/spec/libraries/install_helpers_spec.rb
+++ b/spec/libraries/install_helpers_spec.rb
@@ -97,4 +97,8 @@ RSpec.describe TomcatCookbook::InstallHelpers do
       end
     end
   end
+
+  # TODO: Add test for fetch_tomcat_checksum
+
+  # TODO: Add test for validate_tomcat_checksum
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+require_relative '../libraries/install_helpers.rb'
+
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter

--- a/test/cookbooks/test/recipes/helloworld_example.rb
+++ b/test/cookbooks/test/recipes/helloworld_example.rb
@@ -24,6 +24,17 @@ tomcat_install 'dirworld' do
   tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.54/bin/apache-tomcat-8.5.54.tar.gz'
   tomcat_user 'cool_user'
   tomcat_group 'cool_group'
+  create_symlink false
+end
+
+# Install Tomcat 8.5.54 to a custom symlink path
+tomcat_install 'symworld' do
+  version '8.5.54'
+  dir_mode '0755'
+  tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.54/bin/apache-tomcat-8.5.54.tar.gz'
+  tomcat_user 'cool_user'
+  tomcat_group 'cool_group'
+  symlink_path '/opt/tomcat_symworld_custom'
 end
 
 # Drop off our own server.xml that uses a non-default port setup

--- a/test/integration/multi_instance/controls/default_spec.rb
+++ b/test/integration/multi_instance/controls/default_spec.rb
@@ -4,6 +4,16 @@ sleep 10
 version_8_5 = attribute('tomcat_version_8_5').tr('.', '_')
 version_7 = attribute('tomcat_version_7').tr('.', '_')
 
+describe file("/opt/tomcat_symworld_custom") do
+  it { should be_symlink }
+  it { should be_linked_to "/opt/tomcat_symworld_#{version_8_5}" }
+end
+
+describe file("/opt/tomcat_helloworld") do
+  it { should be_symlink }
+  it { should be_linked_to "/opt/tomcat_helloworld_#{version_8_5}" }
+end
+
 describe file("/opt/tomcat_helloworld_#{version_8_5}") do
   it { should be_directory }
   it { should be_owned_by 'cool_user' }
@@ -17,6 +27,10 @@ if file('/etc/init/tomcat_helloworld.conf').exist?
     its('content') { should match(%r{env CATALINA_BASE="/opt/tomcat_helloworld/"}) }
     its('content') { should_not match(%r{env CATALINA_BASE="/opt/tomcat_helloworld"}) }
   end
+end
+
+describe file("/opt/tomcat_dirworld") do
+  it { should_not exist }
 end
 
 describe file("/opt/tomcat_dirworld_#{version_8_5}") do

--- a/test/integration/multi_instance/controls/default_spec.rb
+++ b/test/integration/multi_instance/controls/default_spec.rb
@@ -4,12 +4,12 @@ sleep 10
 version_8_5 = attribute('tomcat_version_8_5').tr('.', '_')
 version_7 = attribute('tomcat_version_7').tr('.', '_')
 
-describe file("/opt/tomcat_symworld_custom") do
+describe file('/opt/tomcat_symworld_custom') do
   it { should be_symlink }
   it { should be_linked_to "/opt/tomcat_symworld_#{version_8_5}" }
 end
 
-describe file("/opt/tomcat_helloworld") do
+describe file('/opt/tomcat_helloworld') do
   it { should be_symlink }
   it { should be_linked_to "/opt/tomcat_helloworld_#{version_8_5}" }
 end
@@ -29,7 +29,7 @@ if file('/etc/init/tomcat_helloworld.conf').exist?
   end
 end
 
-describe file("/opt/tomcat_dirworld") do
+describe file('/opt/tomcat_dirworld') do
   it { should_not exist }
 end
 


### PR DESCRIPTION
# Description

Refactors `tomcat_install` by abstracting many values into functions (moving to a helper library) in preparation for eventual Windows support.

Adds `create_symlink` property for those that do not want to create a symlink

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
