### PR TITLE
Adds support for specifying `file://` paths for `checksum_uri` on `tomcat_install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the tomcat cookbook.
 
 ## Unreleased
 
+- Adds support for specifying `file://` paths for `checksum_uri` on `tomcat_install`
+
 ## 4.1.0 - *2021-01-19*
 
 - Added Tomcat 10 support for `tomcat_install`

--- a/test/cookbooks/test/recipes/helloworld_example.rb
+++ b/test/cookbooks/test/recipes/helloworld_example.rb
@@ -9,10 +9,21 @@ group 'cool_group' do
   action :create
 end
 
+remote_file "#{Chef::Config['file_cache_path']}/apache-tomcat-10.0.0.tar.gz" do
+  source 'http://archive.apache.org/dist/tomcat/tomcat-10/v10.0.0/bin/apache-tomcat-10.0.0.tar.gz'
+  action :create
+end
+
+remote_file "#{Chef::Config['file_cache_path']}/apache-tomcat-10.0.0.tar.gz.sha512" do
+  source 'http://archive.apache.org/dist/tomcat/tomcat-10/v10.0.0/bin/apache-tomcat-10.0.0.tar.gz.sha512'
+  action :create
+end
+
 # Install Tomcat 8.5.54 to the default location
 tomcat_install 'helloworld' do
   version '10.0.0'
-  tarball_uri 'http://archive.apache.org/dist/tomcat/tomcat-10/v10.0.0/bin/apache-tomcat-10.0.0.tar.gz'
+  tarball_uri "file://#{Chef::Config['file_cache_path']}/apache-tomcat-10.0.0.tar.gz"
+  checksum_uri "file://#{Chef::Config['file_cache_path']}/apache-tomcat-10.0.0.tar.gz.sha512"
   tomcat_user 'cool_user'
   tomcat_group 'cool_group'
 end


### PR DESCRIPTION
# Description

Adds support for specifying `file://` paths for `checksum_uri` on `tomcat_install`

## Issues Resolved

Fixes #364 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
