### PR TITLE
Correct ubuntu-20.04 platform image

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -57,7 +57,7 @@ platforms:
 
   - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update


### PR DESCRIPTION
Changed image of platform ubuntu-20.04 from dokken/ubuntu-18.04 (the wrong one) to dokken/ubuntu-20.04 (the right one).

# Description

Corrected a typo in platform ubuntu-20.04 in the kitchen.dokken.yml file. The typo is dokken/ubuntu-18.04. Changed it to the correct value dokken/ubuntu-20.04.

